### PR TITLE
Usable application

### DIFF
--- a/src/main/java/marrf/iscte/App.java
+++ b/src/main/java/marrf/iscte/App.java
@@ -1102,8 +1102,10 @@ public class App extends Application {
         ParametricCompositionShape temp = newParametricCompositionShapes.stream().filter(p -> p.getUUID().toString().equals(uuidToRemove)).findFirst().get();
         newParametricCompositionShapes.remove(temp);
         GridCanvas.clearEverything();
+        sectionToKeep.getChildren().clear();
         transformersBox.getChildren().clear();
         sideBarThumbnails.remove(temp);
+
 
         newParametricCompositionShapes.forEach(p -> p.removeParametricCompositionShapeWithID(uuidToRemove));
         //Temos que ir às outras parametric onde esta pode ter sido usada, e apagar esta!
@@ -1139,7 +1141,7 @@ public class App extends Application {
         }
 
         newParametricCompositionShapes.forEach(ParametricCompositionShape::redrawThumbnail);
-
+        saveCurrentShape();
     }
 
     private void deleteCompositionShape(String uuidToRemove){

--- a/src/main/java/marrf/iscte/NewShapeRuleEditor.java
+++ b/src/main/java/marrf/iscte/NewShapeRuleEditor.java
@@ -20,6 +20,7 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 import marrf.iscte.ShapeRules.*;
+import org.json.simple.JSONArray;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -445,6 +446,65 @@ public class NewShapeRuleEditor {
         return toReturn.toString();
     }
 
+    public  String getProcessAndRulesJSON(){
+        StringBuilder toReturn = new StringBuilder();
+
+        orchestrator.getProcesses().forEach(process -> {
+            toReturn.append("[\n");
+
+            toReturn.append("\"").append(process.getProcessName()).append("\",\n");
+            toReturn.append("\"").append(process.getProcessName()).append("\"\n");
+
+            toReturn.append("],\n");
+        });
+
+        orchestrator.getShapeRules().forEach(shapeRule -> {
+            toReturn.append("[\n");
+
+            toReturn.append("\"").append(shapeRule.getShapeRuleName()).append("\",\n");
+            toReturn.append("\"").append(shapeRule.getShapeRuleName()).append("\"\n");
+
+            toReturn.append("],\n");
+        });
+
+        return toReturn.toString();
+    }
+    public JSONArray getProcessAndRulesJSONToJSON(){
+        JSONArray jsonArray = new JSONArray();
+
+        orchestrator.getProcesses().forEach(process -> {
+            JSONArray innerJSONArray = new JSONArray();
+
+            innerJSONArray.add(process.getProcessName());
+            innerJSONArray.add(process.getProcessName());
+
+
+            jsonArray.add(innerJSONArray);
+        });
+
+        orchestrator.getShapeRules().forEach(shapeRule -> {
+            JSONArray innerJSONArray = new JSONArray();
+
+            innerJSONArray.add(shapeRule.getShapeRuleName());
+            innerJSONArray.add(shapeRule.getShapeRuleName());
+
+
+            jsonArray.add(innerJSONArray);
+        });
+        return jsonArray;
+    }
+
+    private void updateProcessesAndRulesNames(WebView webView){
+        JSONArray processAndRulesToSend = getProcessAndRulesJSONToJSON();
+        System.out.println("vou colocar: ");
+        System.out.println(processAndRulesToSend.toJSONString());
+        webView.getEngine().executeScript("updateProcessesAndRulesNames('" + processAndRulesToSend.toJSONString() +"')");
+        System.out.println("updateProcessesAndRulesNamesToolBox: ");
+        System.out.println( processAndRulesToSend.toJSONString());
+        webView.getEngine().executeScript("updateProcessesAndRulesNamesToolBox('" + processAndRulesToSend.toJSONString() +"')");
+        //webView.getEngine().executeScript("addUpdateProcessesAndRulesNamesSectionToToolBox()");
+    }
+
     private File setUpFiles(String fileName){
         Path htmlOriginal = Paths.get(Orchestrator.path + "/" + fileName + ".html");
 
@@ -463,6 +523,12 @@ public class NewShapeRuleEditor {
             Files.copy(htmlOriginal, htmlCopied, StandardCopyOption.REPLACE_EXISTING);
 
             String fileContentJS = new String(Files.readAllBytes(htmlCopied));
+
+            if(orchestrator.getProcesses().size() != 0 || orchestrator.getShapeRules().size() != 0){
+                fileContentJS = fileContentJS.replace("<!--CHANGE_HERE_3-->", "<block type=\"availableProcessesAndRules\"></block>" );
+            }
+
+
             fileContentJS = fileContentJS.replace("myBlocksCopied.js","myBlocksCopied.js?c=r_" + randomNum);
             Files.write(htmlCopied, fileContentJS.getBytes());
 
@@ -474,7 +540,7 @@ public class NewShapeRuleEditor {
 
 
             String fileContent = new String(Files.readAllBytes(copied));
-            fileContent = fileContent.replace("//CHANGE_HERE", "{\n" +
+            fileContent = fileContent.replace("//CHANGE_HERE1", "{\n" +
                     "  \"type\": \"availableshapes\",\n" +
                     "  \"message0\": \"%1\",\n" +
                     "  \"args0\": [\n" +
@@ -491,6 +557,26 @@ public class NewShapeRuleEditor {
                     "  \"tooltip\": \"\",\n" +
                     "  \"helpUrl\": \"\"\n" +
                     "},");
+
+            fileContent = fileContent.replace("//CHANGE_HERE2", "{\n" +
+                    "  \"type\": \"availableProcessesAndRules\",\n" +
+                    "  \"message0\": \"%1\",\n" +
+                    "  \"args0\": [\n" +
+                    "    {\n" +
+                    "      \"type\": \"field_dropdown\",\n" +
+                    "      \"name\": \"NAME\",\n" +
+                    "      \"options\": [\n" +
+                    "       " + getProcessAndRulesJSON() +
+                    "      ]\n" +
+                    "    }\n" +
+                    "  ],\n" +
+                    "  \"output\": null,\n" +
+                    "  \"colour\": 20,\n" +
+                    "  \"tooltip\": \"\",\n" +
+                    "  \"helpUrl\": \"\"\n" +
+                    "},");
+
+
             Files.write(copied, fileContent.getBytes());
 
 
@@ -591,6 +677,7 @@ public class NewShapeRuleEditor {
                         if(t1 == Worker.State.SUCCEEDED){
                             webView.getEngine().executeScript("novoTeste('"+ currentShapeRule.getBoolXML() +"')");
                             startBlurAnimation(vBox, 30.0, 0.0, Duration.millis(100), false);
+                            updateProcessesAndRulesNames(webView);
 
                         }
                     });
@@ -605,6 +692,7 @@ public class NewShapeRuleEditor {
                         if(t1 == Worker.State.SUCCEEDED){
                             webView.getEngine().executeScript("novoTeste('"+ currentShapeRule.getProcessXML() +"')");
                             startBlurAnimation(vBox, 30.0, 0.0, Duration.millis(100), false);
+                            updateProcessesAndRulesNames(webView);
 
                         }
                     });


### PR DESCRIPTION
- There was a bug when deleting a parametric composition shape, as it wouldn't remove the 'sectionTooKeep' panel.
- When deleting a parametric composition shape all the shapes are saved.

NewShapeRuleEditor:
- Processes and rules are obtainable as JSON to send to javascript.
 - Processes and Rules names are updated via javascript.
 - Processes can now be selected, as well as all other figures.
 - Parametric Composition Shapes also have a graphical representation as a block in Blockly.

 Similar changes were made to the ProcessesEditor.
 The biggest difficulty was with the parametric composition shapes blocks from Blockly, as the dependencies are hard to manage.